### PR TITLE
Remove debug from application

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -26,6 +26,7 @@ class HrApp extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       title: 'HR App',
+      debugShowCheckedModeBanner: false,
       theme: ThemeData(
         primarySwatch: Colors.blue,
         useMaterial3: true,


### PR DESCRIPTION
Remove the debug banner from the `MaterialApp` widget.

---
<a href="https://cursor.com/background-agent?bcId=bc-8139009f-b6da-4910-a856-514480a9651c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8139009f-b6da-4910-a856-514480a9651c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

